### PR TITLE
Cards - Update Date

### DIFF
--- a/tests/api/date/date-update.spec.ts
+++ b/tests/api/date/date-update.spec.ts
@@ -1,4 +1,3 @@
-// tests/api/cards/cards-update-dates.spec.ts
 import { test, expect } from '@playwright/test';
 import { TrelloRequest } from '../../../utils/api/trello-request';
 import { createBoardForSuite, deleteBoard } from '../../../utils/api/base-helper';


### PR DESCRIPTION
- Agregando test api de modificar la fecha

<img width="1903" height="887" alt="image" src="https://github.com/user-attachments/assets/c76b414b-522c-4002-99cd-5210603d3a12" />

Me aparece este bug
- El bug sucede cuando se pograma un card para el pasado xd 
La API acepta una fecha de vencimiento (due) anterior al inicio (start) y responde con 200 OK, cuando debería retornar un error 400 o 422 por inconsistencia lógica.

<img width="1270" height="557" alt="image" src="https://github.com/user-attachments/assets/63d2af08-8a57-43b6-b1eb-5b04a8cb1cb2" />


